### PR TITLE
Exclude flag and more regexes

### DIFF
--- a/django-template-i18n-lint.py
+++ b/django-template-i18n-lint.py
@@ -62,7 +62,9 @@ GOOD_STRINGS = re.compile(
         # Any html attribute that's not value or title
         |[a-z:-]+?(?<!alt)(?<!value)(?<!title)(?<!summary)=[^\W]*?[(\w|>)]
         
-        |[(SELECTED|CHECKED)]
+        |SELECTED
+        
+        |CHECKED
 
          # HTML opening tag
         |<[\w:]+
@@ -103,7 +105,7 @@ GOOD_STRINGS = re.compile(
         )""",
 
     # MULTILINE to match across lines and DOTALL to make . include the newline
-    re.MULTILINE|re.DOTALL|re.VERBOSE)
+    re.MULTILINE|re.DOTALL|re.VERBOSE|re.IGNORECASE)
 
 # Stops us matching non-letter parts, e.g. just hypens, full stops etc.
 LETTERS = re.compile("\w")
@@ -121,7 +123,10 @@ def replace_strings(filename):
         full_text_lines.append(message)
 
     full_text = "".join(full_text_lines)
-    save_filename = filename.split(".")[0] + "_translated.html"
+    if options.overwrite:
+        save_filename = filename
+    else:
+        save_filename = filename.split(".")[0] + "_translated.html"
     open(save_filename, 'w').write(full_text)
     print "Fully translated! Saved as: %s" % save_filename
 
@@ -152,6 +157,8 @@ if __name__ == '__main__':
     parser = OptionParser(usage="usage: %prog [options] <filenames>")
     parser.add_option("-r", "--replace", action="store_true", dest="replace",
                       help="Ask to replace the strings in the file.", default=False)
+    parser.add_option("-o", "--overwrite", action="store_true", dest="overwrite",
+                      help="When replacing the strings, overwrite the original file.  If not specified, the file will be saved in a seperate file named X_translated.html", default=False)
     parser.add_option("-e", "--exclude", action="append", dest="exclude_filename",
                       help="Exclude these filenames from being linted")
     (options, args) = parser.parse_args()


### PR DESCRIPTION
This adds a `-e` flag to the script to exclude certain filenames from being checked.

It also adds a handful of regexes to not catch strings that shouldn't be translated.
