### PR TITLE
add boolean html attributes

### DIFF
--- a/django_template_i18n_lint.py
+++ b/django_template_i18n_lint.py
@@ -63,7 +63,7 @@ GOOD_STRINGS = re.compile(
         |[a-z:-]+?(?<!alt)(?<!value)(?<!title)(?<!summary)=[^\W]*?[(\w|>)]
 
          # Boolean attributes
-        |<[^<>]+?(?:checked|selected|disabled|readonly|multiple|ismap|defer|declare|noresize|nowrap|noshade|compact)[^<>]+?>
+        |<[^<>]+?(?:checked|selected|disabled|readonly|multiple|ismap|defer|declare|noresize|nowrap|noshade|compact)[^<>]*?>
 
          # HTML opening tag
         |<[\w:]+

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,8 @@ class DjangoTemplateI18nLintTestCase(unittest.TestCase):
     testDjangoCustomTag = _known_good_output("{% load foo %}", [])
     testJS = _known_good_output("Foo<script>alert('Foo');</script>Bar", [(1, 1, 'Foo'), (1, 34, 'Bar')])
     testDjangoVar = _known_good_output("Foo{{ bar }}Baz", [(1, 1, 'Foo'), (1, 13, 'Baz')])
+    testBooleanValuesOK1 = _known_good_output("<option selected>Option</option>",[(1, 18, 'Option')])
+    testBooleanValuesOK2 = _known_good_output("<img src='my.jpg' ismap />",[])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Boolean HTML attributes were uncaught except for `selected` and `checked`.
