### PR TITLE
Fix error in replace_strings function

### DIFF
--- a/django_template_i18n_lint.py
+++ b/django_template_i18n_lint.py
@@ -162,7 +162,7 @@ def replace_strings(filename, overwrite=False, force=False, accept=[]):
                 full_text_lines.append(leading_whitespace)
 
                 # Find location of first letter
-                lineno, charpos = location(template, offset+m.span()[0])
+                lineno, charpos = location(string, offset+m.span()[0])
 
                 if any(r.match(message) for r in accept):
                     full_text_lines.append(message)
@@ -170,14 +170,14 @@ def replace_strings(filename, overwrite=False, force=False, accept=[]):
                     full_text_lines.append(message)
                 elif force:
                     full_text_lines.append('{% trans "'+message.replace('"', '\\"')+'" %}')
-                    
+
                 else:
-                    change = raw_input("Make %r translatable? [Y/n] " % message)                
+                    change = raw_input("Make %r translatable? [Y/n] " % message)
                     if change == 'y' or change == "":
                         full_text_lines.append('{% trans "'+message.replace('"', '\\"')+'" %}')
                     else:
                         full_text_lines.append(message)
-                        
+
                 full_text_lines.append(trailing_whitespace)
         offset += len(string)
 


### PR DESCRIPTION
This PR fixes an error caused when attempting use the replace functionality

```
$ django-template-i18n-lint -r -o templates/home.html
Traceback (most recent call last):
  File "/Users/fmr/.virtualenvs/testproject/bin/django-template-i18n-lint", line 9, in <module>
    load_entry_point('django-template-i18n-lint==1.2.0', 'console_scripts', 'django-template-i18n-lint')()
  File "/Users/fmr/.virtualenvs/testproject/lib/python2.7/site-packages/django_template_i18n_lint.py", line 275, in main
    replace_strings(filename, overwrite=True, force=options.force, accept=accept_regexes)
  File "/Users/fmr/.virtualenvs/testproject/lib/python2.7/site-packages/django_template_i18n_lint.py", line 165, in replace_strings
    lineno, charpos = location(template, offset+m.span()[0])
NameError: global name 'template' is not defined
```