### PR TITLE
Provide raw_input equivalent for Python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
   - "3.3"
 install:
-    - pip install coveralls --use-mirrors
+    - pip install coveralls
 # command to run tests
 script:
   coverage run --source=django_template_i18n_lint setup.py test

--- a/django_template_i18n_lint.py
+++ b/django_template_i18n_lint.py
@@ -172,7 +172,10 @@ def replace_strings(filename, overwrite=False, force=False, accept=[]):
                     full_text_lines.append('{% trans "'+message.replace('"', '\\"')+'" %}')
 
                 else:
-                    change = raw_input("Make %r translatable? [Y/n] " % message)
+                    # Support Python 3.x
+                    try: input = raw_input
+                    except NameError: pass
+                    change = input("Make %r translatable? [Y/n] " % message)
                     if change == 'y' or change == "":
                         full_text_lines.append('{% trans "'+message.replace('"', '\\"')+'" %}')
                     else:


### PR DESCRIPTION
Hi Rory, I've tested that this works

Found the solution on [Stack Overflow](http://stackoverflow.com/questions/954834/how-do-i-use-raw-input-in-python-3)

Please have a look!
