### PR TITLE
Add data- attributes to GOOD_STRINGS

### DIFF
--- a/django_template_i18n_lint.py
+++ b/django_template_i18n_lint.py
@@ -63,7 +63,7 @@ GOOD_STRINGS = re.compile(
         |(?:['"]\W+)?(?:data-|data-original-)?(?:alt|value|title|summary)=['"]?
 
          # Boolean attributes
-        |<[^<>]+?(?:checked|selected|disabled|readonly|multiple|ismap|defer|async|declare|noresize|nowrap|noshade|compact|hidden|itemscope|autofocus|autoplay|controls|download)[^<>]*?>
+        |<[^<>]+?(?:checked|selected|disabled|readonly|multiple|ismap|defer|async|declare|noresize|nowrap|noshade|compact|hidden|itemscope|autofocus|autoplay|controls|download|data-(?:(?!=)[a-z-]+(?=[<> /]))+)[^<>]*?>
 
          # HTML opening tag
         |<[\w:]+

--- a/tests.py
+++ b/tests.py
@@ -33,6 +33,8 @@ class DjangoTemplateI18nLintTestCase(unittest.TestCase):
     testDjangoVar = _known_good_output("Foo{{ bar }}Baz", [(1, 1, 'Foo'), (1, 13, 'Baz')])
     testBooleanValuesOK1 = _known_good_output("<option selected>Option</option>",[(1, 18, 'Option')])
     testBooleanValuesOK2 = _known_good_output("<img src='my.jpg' ismap />",[])
+    testBooleanValuesOK3 = _known_good_output("<img src='my.jpg' ismap data-foo/>",[])
+    testBooleanValuesOK4 = _known_good_output("<img src='my.jpg' data-bar ismap/>",[])
 
     testNoHTMLAttrSingleQuote = _known_good_output("<form method='POST'>FOO</form>", [(1, 21, 'FOO')])
     testNoHTMLAttrDoubleQuote = _known_good_output("<form method=\"POST\">FOO</form>", [(1, 21, 'FOO')])


### PR DESCRIPTION
Boolean data attributes (e.g. data-foo) should not be translated,
whereas those which take values (data-title="foo") should be.